### PR TITLE
fix(makefile): use package path in install target to produce correct binary name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ build:
 
 # 安装到 GOPATH/bin
 install:
-	go install $(MAIN_FILE)
+	go install ./cmd/maxclaw
 
 # 运行测试
 test:


### PR DESCRIPTION
## Problem

`make install` installs the binary as `main` instead of `maxclaw`, making the installed binary unusable:

```
$ make install
$ maxclaw status
zsh: command not found: maxclaw
$ ls $(go env GOPATH)/bin/main   # the binary was named "main"
```

This affects every user who follows the documented `make install` workflow.

## Root Cause

The `install` target reuses `MAIN_FILE=cmd/maxclaw/main.go`:

```makefile
install:
	go install $(MAIN_FILE)   # expands to: go install cmd/maxclaw/main.go
```

`go build -o` explicitly sets the output name, so the `build` target is unaffected. However, `go install` does not support the `-o` flag — when given a **file path**, it derives the binary name from the **filename** (`main`); when given a **package path**, it uses the **directory name** (`maxclaw`).

## Fix

Change the `install` target to use the package path:

```makefile
install:
	go install ./cmd/maxclaw
```

This is the idiomatic Go approach (`go install ./<path-to-package>`) and produces the correct binary name `maxclaw`.

## Scope

- **Only one line changed** in `Makefile`
- **No impact on other targets**: `build` still uses `MAIN_FILE` with `-o`, which works correctly
- **No new dependencies or variables introduced**

## Verification

```bash
# Before fix
make install && ls $(go env GOPATH)/bin/main      # ✅ exists (wrong name)
make install && ls $(go env GOPATH)/bin/maxclaw    # ❌ not found

# After fix
make install && ls $(go env GOPATH)/bin/maxclaw    # ✅ exists (correct name)
make build                                          # ✅ still works as before
```